### PR TITLE
Suggest running docker interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ file to trigger it from that repo.
 ```sh
 # Labels requires Docker 1.7, if you get an error remove them.
 docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll \
-  -t -p 127.0.0.1:4000:4000 jekyll/jekyll jekyll s
+  -ti -p 127.0.0.1:4000:4000 jekyll/jekyll jekyll s
 ```
 
 ***If you do not provide a command then it will default to `jekyll s`.***


### PR DESCRIPTION
After starting the container as per the running guide, the last message reads:
```
Server running... press ctrl-c to stop.
```
Ctrl+c does not stop the container, as the suggested instructions do not contain the interactive `-i` parameter. This could be misleading to the user, so this PR adds this parameter to the running instructions in the Readme file.