### PR TITLE
Fixing for docker-machine on OS-X/Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ file to trigger it from that repo.
 ```sh
 # Labels requires Docker 1.7, if you get an error remove them.
 docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll \
-  -it -p 127.0.0.1:4000:4000 jekyll/jekyll jekyll s
+  -it -p 4000:4000 jekyll/jekyll jekyll s
 ```
 
 ***If you do not provide a command then it will default to `jekyll s`.***


### PR DESCRIPTION
For people who run Docker in Docker Machine, the IP is not going to be 127.0.0.1, but something more like 10.211.55.5. Hardcoded 127.0.0.1 in the instructions is both unnecessary and actually breaks things for Mac and Windows users.