### PR TITLE
Updated `jekyll` script to allow `JEKYLL_ENV` variable to be set

### DIFF
--- a/cache/3.0.1/copy/usr/local/bin/jekyll
+++ b/cache/3.0.1/copy/usr/local/bin/jekyll
@@ -26,7 +26,7 @@ def s?
 end
 
 ARGV.shift and ARGV.unshift("serve") if "s" == ARGV[0]
-ARGV.push("--future", "--unpublished") if (!ENV["JEKYLL_ENV"] || ENV["JEKYLL_ENV"] = "development") && (b? || s?) && !_24?
+ARGV.push("--future", "--unpublished") if (!ENV["JEKYLL_ENV"] || ENV["JEKYLL_ENV"] == "development") && (b? || s?) && !_24?
 ARGV.push("--force_polling") if (ENV["FORCE_POLLING"] || ENV["POLLING"]) && (b? || s?)
 ARGV.push("--verbose") if ENV["DEBUG"] || ENV["VERBOSE"]
 ARGV.unshift(ARGV.shift, "-H", "0.0.0.0") if s?

--- a/cache/3.0/copy/usr/local/bin/jekyll
+++ b/cache/3.0/copy/usr/local/bin/jekyll
@@ -26,7 +26,7 @@ def s?
 end
 
 ARGV.shift and ARGV.unshift("serve") if "s" == ARGV[0]
-ARGV.push("--future", "--unpublished") if (!ENV["JEKYLL_ENV"] || ENV["JEKYLL_ENV"] = "development") && (b? || s?) && !_24?
+ARGV.push("--future", "--unpublished") if (!ENV["JEKYLL_ENV"] || ENV["JEKYLL_ENV"] == "development") && (b? || s?) && !_24?
 ARGV.push("--force_polling") if (ENV["FORCE_POLLING"] || ENV["POLLING"]) && (b? || s?)
 ARGV.push("--verbose") if ENV["DEBUG"] || ENV["VERBOSE"]
 ARGV.unshift(ARGV.shift, "-H", "0.0.0.0") if s?

--- a/cache/builder/copy/usr/local/bin/jekyll
+++ b/cache/builder/copy/usr/local/bin/jekyll
@@ -26,7 +26,7 @@ def s?
 end
 
 ARGV.shift and ARGV.unshift("serve") if "s" == ARGV[0]
-ARGV.push("--future", "--unpublished") if (!ENV["JEKYLL_ENV"] || ENV["JEKYLL_ENV"] = "development") && (b? || s?) && !_24?
+ARGV.push("--future", "--unpublished") if (!ENV["JEKYLL_ENV"] || ENV["JEKYLL_ENV"] == "development") && (b? || s?) && !_24?
 ARGV.push("--force_polling") if (ENV["FORCE_POLLING"] || ENV["POLLING"]) && (b? || s?)
 ARGV.push("--verbose") if ENV["DEBUG"] || ENV["VERBOSE"]
 ARGV.unshift(ARGV.shift, "-H", "0.0.0.0") if s?

--- a/cache/latest/copy/usr/local/bin/jekyll
+++ b/cache/latest/copy/usr/local/bin/jekyll
@@ -26,7 +26,7 @@ def s?
 end
 
 ARGV.shift and ARGV.unshift("serve") if "s" == ARGV[0]
-ARGV.push("--future", "--unpublished") if (!ENV["JEKYLL_ENV"] || ENV["JEKYLL_ENV"] = "development") && (b? || s?) && !_24?
+ARGV.push("--future", "--unpublished") if (!ENV["JEKYLL_ENV"] || ENV["JEKYLL_ENV"] == "development") && (b? || s?) && !_24?
 ARGV.push("--force_polling") if (ENV["FORCE_POLLING"] || ENV["POLLING"]) && (b? || s?)
 ARGV.push("--verbose") if ENV["DEBUG"] || ENV["VERBOSE"]
 ARGV.unshift(ARGV.shift, "-H", "0.0.0.0") if s?

--- a/cache/pages/copy/usr/local/bin/jekyll
+++ b/cache/pages/copy/usr/local/bin/jekyll
@@ -26,7 +26,7 @@ def s?
 end
 
 ARGV.shift and ARGV.unshift("serve") if "s" == ARGV[0]
-ARGV.push("--future", "--unpublished") if (!ENV["JEKYLL_ENV"] || ENV["JEKYLL_ENV"] = "development") && (b? || s?) && !_24?
+ARGV.push("--future", "--unpublished") if (!ENV["JEKYLL_ENV"] || ENV["JEKYLL_ENV"] == "development") && (b? || s?) && !_24?
 ARGV.push("--force_polling") if (ENV["FORCE_POLLING"] || ENV["POLLING"]) && (b? || s?)
 ARGV.push("--verbose") if ENV["DEBUG"] || ENV["VERBOSE"]
 ARGV.unshift(ARGV.shift, "-H", "0.0.0.0") if s?

--- a/copy/all/usr/local/bin/jekyll
+++ b/copy/all/usr/local/bin/jekyll
@@ -26,7 +26,7 @@ def s?
 end
 
 ARGV.shift and ARGV.unshift("serve") if "s" == ARGV[0]
-ARGV.push("--future", "--unpublished") if (!ENV["JEKYLL_ENV"] || ENV["JEKYLL_ENV"] = "development") && (b? || s?) && !_24?
+ARGV.push("--future", "--unpublished") if (!ENV["JEKYLL_ENV"] || ENV["JEKYLL_ENV"] == "development") && (b? || s?) && !_24?
 ARGV.push("--force_polling") if (ENV["FORCE_POLLING"] || ENV["POLLING"]) && (b? || s?)
 ARGV.push("--verbose") if ENV["DEBUG"] || ENV["VERBOSE"]
 ARGV.unshift(ARGV.shift, "-H", "0.0.0.0") if s?


### PR DESCRIPTION
At current, it doesn't seem to be possible to set the `JEKYLL_ENV` variable to anything other than `development`, which is problematic for those who do not wish to publish pages marked with `published: false`.

The changes included in this pull request are intended to allow users to set the `JEKYLL_ENV` variable to values other than `development`.

Would it be fair to assume that the fact that this feature was not available before was a bug?