### PR TITLE
Don't do unexpected things to ARGV

### DIFF
--- a/copy/all/usr/local/bin/jekyll
+++ b/copy/all/usr/local/bin/jekyll
@@ -1,16 +1,5 @@
 #!/usr/bin/env ruby
 
-def _24?
-  @_24 || begin
-    Gem::Version.new(ENV["JEKYLL_VERSION"].split("@") \
-      .last) == Gem::Version.new("2.4")
-  rescue
-    false
-  end
-end
-
-#
-
 def b?
   %W(b build).include?(
     ARGV[0]
@@ -26,7 +15,6 @@ def s?
 end
 
 ARGV.shift and ARGV.unshift("serve") if "s" == ARGV[0]
-ARGV.push("--future", "--unpublished", "--drafts") if (!ENV["JEKYLL_ENV"] || ENV["JEKYLL_ENV"] == "development") && (b? || s?) && !_24?
 ARGV.push("--force_polling") if (ENV["FORCE_POLLING"] || ENV["POLLING"]) && (b? || s?)
 ARGV.push("--verbose") if ENV["DEBUG"] || ENV["VERBOSE"]
 ARGV.unshift(ARGV.shift, "-H", "0.0.0.0") if s?


### PR DESCRIPTION
This removes an undocumented and potentially destructive code path from `/usr/local/bin/jekyll`.

You wouldn't expect jekyll to build drafts and future posts unless you *set* an environment variable to something that isn't 'development'.

The `JEKYLL_ENV` environment variable is not mentioned in jekyll/docker's README. If this feature is useful it should at least be opt-in.