### PR TITLE
Add liveserve to the commands that have host set

### DIFF
--- a/repos/jekyll/copy/all/usr/local/bin/jekyll
+++ b/repos/jekyll/copy/all/usr/local/bin/jekyll
@@ -9,7 +9,7 @@ end
 #
 
 def serve?
-  %W(s serve server).include?(
+  %W(s serve server liveserve).include?(
     ARGV[0]
   )
 end


### PR DESCRIPTION
When using the hawkins gem to provide live reload, jekyll is loaded using `jekyll liveserve`. This change adds `liveserve` to the list of commands that activate the `-H 0.0.0.0` argument.