### PR TITLE
docker: Support timezones

### DIFF
--- a/repos/jekyll/Dockerfile
+++ b/repos/jekyll/Dockerfile
@@ -16,7 +16,7 @@ RUN \
     libffi-dev ruby-dev yaml-dev zlib-dev libxslt-dev readline-dev libxml2-dev \
     libffi-dev ruby-dev yaml-dev zlib libxml2 build-base ruby-io-console readline \
     libxslt ruby yaml libffi nodejs ruby-irb ruby-json ruby-rake ruby-rdoc \
-    git <% if @meta.packages? %><%= @meta.packages %><% end %> && \
+    git tzdata <% if @meta.packages? %><%= @meta.packages %><% end %> && \
 
   yes | gem update --no-document -- --use-system-libraries && \
   yes | gem update --system --no-document -- --use-system-libraries && \


### PR DESCRIPTION
When I am providing timezone to a container via the TZ environment variable, it isn't getting picked since the `/usr/share/zoneinfo` (`tzdata` package) is missing.
This causes 2 hours difference in the container's logs.

Below is the evidence showing this behavior:

```
host $ docker exec -ti gogs bash

bash-4.3# echo $TZ
Europe/Amsterdam

bash-4.3# date                                                                                                                                          
Sun Jul 10 08:48:12 GMT 2016

bash-4.3# apk add tzdata
(1/1) Installing tzdata (2015g-r0)
Executing busybox-1.24.2-r0.trigger
OK: 40 MiB in 32 packages

bash-4.3# date
Sun Jul 10 10:49:30 CEST 2016
```