### PR TITLE
support incremental and drafts flags to be passed to the container

### DIFF
--- a/repos/jekyll/copy/all/usr/local/bin/jekyll
+++ b/repos/jekyll/copy/all/usr/local/bin/jekyll
@@ -17,6 +17,8 @@ end
 ARGV.shift and ARGV.unshift("serve") if "s" == ARGV[0]
 ARGV.push("--force_polling") if (ENV["FORCE_POLLING"] || ENV["POLLING"]) && (build? || serve?)
 ARGV.push("--verbose") if ENV["DEBUG"] || ENV["VERBOSE"]
+ARGV.push("--incremental") if ENV["INCREMENTAL"]
+ARGV.push("--drafts") if ENV["DRAFTS"]
 ARGV.unshift(ARGV.shift, "-H", "0.0.0.0") if serve?
 
 if Process.uid == 0 || Process.euid == 0

--- a/repos/jekyll/copy/all/usr/local/bin/jekyll
+++ b/repos/jekyll/copy/all/usr/local/bin/jekyll
@@ -17,7 +17,6 @@ end
 ARGV.shift and ARGV.unshift("serve") if "s" == ARGV[0]
 ARGV.push("--force_polling") if (ENV["FORCE_POLLING"] || ENV["POLLING"]) && (build? || serve?)
 ARGV.push("--verbose") if ENV["DEBUG"] || ENV["VERBOSE"]
-ARGV.push("--incremental") if ENV["INCREMENTAL"]
 ARGV.push("--drafts") if ENV["DRAFTS"]
 ARGV.unshift(ARGV.shift, "-H", "0.0.0.0") if serve?
 


### PR DESCRIPTION
Missing those flags as options to run a jekyll page in a dev environment.