### PR TITLE
Improve #151: updated Gemfiles backup

### DIFF
--- a/repos/jekyll/copy/all/usr/local/bin/jekyll
+++ b/repos/jekyll/copy/all/usr/local/bin/jekyll
@@ -45,11 +45,13 @@ if [ -f Gemfile ]; then
     apk --update add build-base ruby-dev
     bundle update -j 12
 
-    cp -a Gemfile* /var/
+    cp -a Gemfile /tmp/Gemfile.offline
+    cp -a Gemfile.lock /tmp/Gemfile.lock.offline
   else
-    if [ -f "/var/Gemfile" ]; then
+    if [ -f "/tmp/Gemfile.offline" ]; then
         echo "Restoring the last updated Gemfiles"
-        cp -a /var/Gemfile* .
+        cp -a /tmp/Gemfile.offline Gemfile
+        cp -a /tmp/Gemfile.lock.offline Gemfile.lock
     fi
   fi
 

--- a/repos/jekyll/copy/all/usr/local/bin/jekyll
+++ b/repos/jekyll/copy/all/usr/local/bin/jekyll
@@ -44,6 +44,13 @@ if [ -f Gemfile ]; then
   if [ "$connected" = "true" ]; then
     apk --update add build-base ruby-dev
     bundle update -j 12
+
+    cp -a Gemfile* /var/
+  else
+    if [ -f "/var/Gemfile" ]; then
+        echo "Restoring the last updated Gemfiles"
+        cp -a /var/Gemfile* .
+    fi
   fi
 
   sudo -EHu jekyll bundle exec ruby \


### PR DESCRIPTION
The commit 748e5cd42 introduced the possibility to run a container offline, avoiding the update of the gems. 
Unfortunately this also implies that the container will run with an old Gemfile, no matter if the gems were updated inside the container, and the bundler may complain about missing dependencies.

This Pull Request does a backup of the Gemfiles after updating the gems (when you're working online) and restores the backup if you are offline.

With this, the user can do:
```bash
$ # online (update the gems in the container for the first time)
$ docker run --name Foo jekyll/jekyll:pages cmd

$ # online (update the gems) or offline (reuse the last updated) 
$ docker start Foo
$ docker stop Foo
```