### PR TITLE
Fix 154: avoid ping

### DIFF
--- a/repos/jekyll/copy/all/usr/local/bin/jekyll
+++ b/repos/jekyll/copy/all/usr/local/bin/jekyll
@@ -45,11 +45,13 @@ if [ -f Gemfile ]; then
     apk --update add build-base ruby-dev
     bundle update -j 12
 
-    cp -a Gemfile* /var/
+    cp -a Gemfile /tmp/Gemfile.offline
+    cp -a Gemfile.lock /tmp/Gemfile.lock.offline
   else
-    if [ -f "/var/Gemfile" ]; then
+    if [ -f "/tmp/Gemfile.offline" ]; then
         echo "Restoring the last updated Gemfiles"
-        cp -a /var/Gemfile* .
+        cp -a /tmp/Gemfile.offline Gemfile
+        cp -a /tmp/Gemfile.lock.offline Gemfile.lock
     fi
   fi
 

--- a/repos/jekyll/copy/all/usr/local/bin/jekyll
+++ b/repos/jekyll/copy/all/usr/local/bin/jekyll
@@ -44,6 +44,13 @@ if [ -f Gemfile ]; then
   if [ "$connected" = "true" ]; then
     apk --update add build-base ruby-dev
     bundle update -j 12
+
+    cp -a Gemfile* /var/
+  else
+    if [ -f "/var/Gemfile" ]; then
+        echo "Restoring the last updated Gemfiles"
+        cp -a /var/Gemfile* .
+    fi
   fi
 
   sudo -EHu jekyll bundle exec ruby \

--- a/repos/jekyll/copy/all/usr/local/bin/jekyll
+++ b/repos/jekyll/copy/all/usr/local/bin/jekyll
@@ -2,7 +2,7 @@
 set -e
 
 connected=true
-ping -c1 google.com 1>/dev/null 2>/dev/null || \
+wget -s www.google.com 1>/dev/null 2>/dev/null || \
   connected=false
 
 if [ "$connected" = "false" ]


### PR DESCRIPTION
The #151 introduced the possibility to skip the update of the gems if there isn't connectivity. To test that it uses ```ping```.
But in some restrictive environments the ICMP probes may be blocked and the issue #154 is proof of that.

To avoid using ```ping``` this PR replaces it by a ```wget``` call. Other possible solutions were thought in #154 and ```wget``` seems to be best of them.