### PR TITLE
Use LABEL instead of MAINTAINER

### DIFF
--- a/repos/jekyll/Dockerfile
+++ b/repos/jekyll/Dockerfile
@@ -1,5 +1,5 @@
 FROM envygeeks/alpine
-MAINTAINER Jekyll Core <hello@jekyllrb.com>
+LABEL maintainer "Jekyll Core <hello@jekyllrb.com>"
 COPY copy/ /
 ENV LANGUAGE=en_US
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
Per docker docs MAINTAINER appears to be deprecated in favor of a more general LABEL command: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated