### PR TITLE
Fix reference to non-existent `jekyll/build` image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Jekyll Docker is a software image that has Jekyll and many of it's dependencies 
 
 * `jekyll/jekyll`: Default image.
 * `jekyll/minimal`: Very minimal image.
-* `jekyll/build`: Includes tools.
+* `jekyll/builder`: Includes tools.
 
 ### Standard
 


### PR DESCRIPTION
The current readme references a docker image that doesn't exist, and later in that same document references it by the proper name. This updates the initial reference to point to a thing that is real.