### PR TITLE
use jekyll group - Mac OS

### DIFF
--- a/repos/jekyll/copy/all/usr/local/bin/jekyll
+++ b/repos/jekyll/copy/all/usr/local/bin/jekyll
@@ -2,15 +2,16 @@
 set -e
 
 : ${JEKYLL_UID:=$(id -u)}
+: ${JEKYLL_GID:=$(id -g)}
 args=$(default-args $@)
 export JEKYLL_UID
 
 if [ "$JEKYLL_UID" != "0" ] && [ "$JEKYLL_UID" != "$(id -u jekyll)" ]; then
   usermod  -u $JEKYLL_UID jekyll
-  groupmod -g $JEKYLL_UID jekyll
+  groupmod -g $JEKYLL_GID jekyll
 fi
 
-chown -R jekyll:jekyll $PWD
+chown -R $JEKYLL_UID:$JEKYLL_GID $PWD
 if connected; then
   depends install
 fi


### PR DESCRIPTION
This PR allows custom group id. Its not a perfect solution.

The problem in Mac OS:
```
$id -u
501
$id -g
20
$id -g -n
pedrocarmona
$id -g -n
staff
```

I run the image and it cant execute chown.

If I go inside the container, before execution: 
```
$ ls -la
-rwxr-xr-x    1 501      dialout       3789 Oct  4 17:36 index.html
```

Group 21 is dialout and there is no user with id 501.

When it I try to use the script it will try to change all the files to jenkins group, which in ubuntu maybe the same as the user, but its not in Mac OS.

With this change:
- it makes it work. 
- inside the container user becames dialout group (in mac os docker hosts), which my have unwanted behaviour/permissions.

