### PR TITLE
Update README.md to make it easier to get started.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The standard images (`jekyll/jekyll`) include a default set of "dev" packages, a
 ```sh
 export JEKYLL_VERSION=3.5
 docker run --rm \
-  --volume=$PWD:/srv/jekyll \
+  --volume="$PWD:/srv/jekyll" \
   -it jekyll/jekyll:$JEKYLL_VERSION \
   jekyll build
 ```
@@ -41,7 +41,7 @@ The builder image comes with extra stuff that is not included in the standard im
 ```sh
 export JEKYLL_VERSION=3.5
 docker run --rm \
-  --volume=$PWD:/srv/jekyll \
+  --volume="$PWD:/srv/jekyll" \
   -it jekyll/builder:$JEKYLL_VERSION \
   jekyll build
 ```
@@ -57,7 +57,7 @@ The minimal image skips all the extra gems, all the extra dev dependencies and l
 ```sh
 export JEKYLL_VERSION=3.5
 docker run --rm \
-  --volume=$PWD:/srv/jekyll \
+  --volume="$PWD:/srv/jekyll" \
   -it jekyll/minimal:$JEKYLL_VERSION \
   jekyll build
 ```
@@ -73,7 +73,7 @@ If you provide a `Gemfile` and would like to update your `Gemfile.lock` you can 
 ```sh
 export JEKYLL_VERSION=3.5
 docker run --rm \
-  --volume=$PWD:/srv/jekyll \
+  --volume="$PWD:/srv/jekyll" \
   -it jekyll/jekyll:$JEKYLL_VERSION \
   depends update
 ```
@@ -89,8 +89,8 @@ You can enable caching in Jekyll Docker by using a `docker --volume` that points
 ```sh
 export JEKYLL_VERSION=3.5
 docker run --rm \
-  --volume=$PWD:/srv/jekyll \
-  --volume=$PWD/vendor/bundle:/usr/local/bundle \
+  --volume="$PWD:/srv/jekyll" \
+  --volume="$PWD/vendor/bundle:/usr/local/bundle" \
   -it jekyll/jekyll:$JEKYLL_VERSION \
   jekyll build
 ```


### PR DESCRIPTION
Greetings. The issue being addressed here is that if the current working directory `$PWD` contains spaces, then you get a rathe cryptic error as the command is incorrectly parsed. (The error I received was `invalid reference format: repository name must be lowercase`, which took some considerable Googling.)

This pull request just adds quotes around the path strings so that they can support directories with spaces in the names.