### PR TITLE
WIP: Add quickstart instructions for VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ docker run --rm \
   sh -c "chown -R jekyll /usr/gem/ && jekyll new $site_name" \
   && cd $site_name
 ```
+
+### Quick start under VS Code
+Install this at /.devcontainer/devcontainer.json:
+
+```json
+{
+    "image": "jekyll/minimal",
+    "forwardPorts": [4000]
+}
+```
+
+Then go to the Run and Debug sidebar and click play.
+
+
 ### Builder
 
 The builder image comes with extra stuff that is not included in the standard image, like `lftp`, `openssh` and other extra packages meant to be used by people who are deploying their Jekyll builds to another server with a CI.


### PR DESCRIPTION
This almost works using GitHub Codespaces (preview).

But the command is complaining about `bundle install` needing to run.

Not sure if the Docker image was supposed to already have bundle install ran inside it before it was published. If not, I'm still seeking the preferred way to do this in the devcontainer.json file as there are [several choices](https://code.visualstudio.com/Docs/editor/debugging#_launchjson-attributes).