### PR TITLE
Chore: Add support Jekyll 3.9.2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,18 +20,27 @@ jobs:
             - jekyll:latest
             - jekyll:4.0
             - jekyll:4
+            - jekyll:3.9.2
+            - jekyll:3.9
+            - jekyll:3
           -
             - builder:4.2.2
             - builder:stable
             - builder:latest
             - builder:4.0
             - builder:4
+            - builder:3.9.2
+            - builder:3.9
+            - builder:3
           -
             - minimal:4.2.2
             - minimal:stable
             - minimal:latest
             - minimal:4.0
             - minimal:4
+            - minimal:3.9.2
+            - minimal:3.9
+            - minimal:3
           - builder:pages
           - minimal:pages
           - jekyll:pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ jobs:
         jekyll:pages \
         jekyll:4.0 \
         jekyll:4 \
+        jekyll:3.0 \
+        jekyll:3 \
       '\
     "
   # --
@@ -50,6 +52,8 @@ jobs:
         builder:pages \
         builder:4.0 \
         builder:4 \
+        builder:3.0 \
+        builder:3 \
       '\
     "
   # --
@@ -64,5 +68,7 @@ jobs:
         minimal:pages \
         minimal:4.0 \
         minimal:4 \
+        minimal:3.0 \
+        minimal:3 \
       '\
     "

--- a/opts.yml
+++ b/opts.yml
@@ -5,9 +5,12 @@ aliases:
   stable: 4.2.2
   4.0: 4.2.2
   4: 4.2.2
+  3.9.2: 3.9.2
+  3.0: 3.9.2
+  3: 3.9.2
 tags:
   4.2.2: stable
   pages: pages
 releases:
   tag:
-    pages: 3.8.5 # 05-15-2020
+    pages: 3.9.2 # 04-18-2022


### PR DESCRIPTION
Add support to version of Jekyll that is currently used in Github Pages. 

:link: https://github.com/github/pages-gem/commit/e0c079b21abb5feb6acec395c96299a8353582b0

Resolve #310 
Replaces #293