### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ docker run --rm \
   -it jekyll/jekyll:$JEKYLL_VERSION \
   jekyll build
 ```
+Notes:
+
+* Leave off `:$JEKYLL_VERSION` to use the latest version. 
+* `:Z` is required for SELinux enabled hosts.
+
 #### Quick start under Windows (cmd)
 ```cmd
 set site_name=my-blog
@@ -30,14 +35,20 @@ docker run --rm --volume="%CD%:/srv/jekyll" -it jekyll/jekyll sh -c "chown -R je
 ```
 #### Quick start under Linux / Git Bash
 If you are under linux skip `export MSYS_NO_PATHCONV=1`. It is added for compatibility. You can check [here](https://github.com/docker-archive/toolbox/issues/673).
+
 ```sh
 export site_name="my-blog" && export MSYS_NO_PATHCONV=1
 docker run --rm \
-  --volume="$PWD:/srv/jekyll" \
+  -e JEKYLL_UID="1000" \
+  -e JEKYLL_GID="1000" \
+  --volume="$PWD:/srv/jekyll:Z" \
   -it jekyll/jekyll \
   sh -c "chown -R jekyll /usr/gem/ && jekyll new $site_name" \
   && cd $site_name
 ```
+
+Note: `JEKYLL_UID="1000"` and `JEKYLL_GID="1000"` are the default values used by the container. Change these to match the target directory owner and group ID to avoid write errors. 
+
 ### Builder
 
 The builder image comes with extra stuff that is not included in the standard image, like `lftp`, `openssh` and other extra packages meant to be used by people who are deploying their Jekyll builds to another server with a CI.
@@ -79,6 +90,16 @@ podman run -ti --rm -v .:/srv/jekyll -e JEKYLL_ROOTLESS=1 docker.io/jekyll/jekyl
 ## Server
 
 For local development, Jekyll can be run in server mode inside the container. It will watch for changes, rebuild the site, and provide access through its included web server. You can then check the results of changes by reloading http://localhost:4000/ in a browser.
+
+[Ruby 3.0 no longer bundles webrick](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/) and so [Jekyll serve fails on Ruby 3.0](https://github.com/jekyll/jekyll/issues/8523). The work around is to `bundle add webrick` before starting `jekyll serve`.
+#### Run once before starting the server
+
+```sh
+docker run --rm \
+  --volume="$PWD:/srv/jekyll:Z" \
+  -it jekyll/jekyll \
+  bundle add webrick
+```
 
 #### Usage
 


### PR DESCRIPTION
Updating README.md to add more information about when ":Z" is required along with updating the Linux quick start example to use this option. A note about "it's okay to not set the JEKYLL_VERSION environment variable", calling out JEKYLL_UID and JEKYLL_GID in one of the examples (that actually took me a while to work out https://ask.fedoraproject.org/t/docker-error-errno-eacces-only-occurs-for-uid-other-than-1000/30524/6) and adding in something about bundle add webrick.