### PR TITLE
Rewrite deploy action to handle multi-arch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,59 +1,81 @@
 name: 'Push'
+
 on:
   push:
     branches:
       - $default-branch
   schedule:
     - cron: 2 4 10 * *
+
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     name: 'Build'
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        env:
-          -
-            - jekyll:4.2.2
-            - jekyll:stable
-            - jekyll:latest
-            - jekyll:4.0
-            - jekyll:4
-          -
-            - builder:4.2.2
-            - builder:stable
-            - builder:latest
-            - builder:4.0
-            - builder:4
-          -
-            - minimal:4.2.2
-            - minimal:stable
-            - minimal:latest
-            - minimal:4.0
-            - minimal:4
-          - builder:pages
-          - minimal:pages
-          - jekyll:pages
+        variant: [jekyll, builder, minimal]
+        main_tag: [latest, pages]
+        include:
+          - main_tag: latest
+            tags: |
+              latest,priority=900
+              4.2.2,priority=700
+              4.2,priority=500
+              4,priority=300
+              stable,priority=100
+          - main_tag: pages
+            tags: pages
+
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-ruby@v1
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.x'
-      - run: bundle install
-      - run: |
-          echo $'{\n    "experimental": true\n}' | \
-            sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-        name: 'docker experimental'
-      - name: 'docker login'
-        run: |
-          echo "${{secrets.DOCKER_PASSWORD}}" | docker login \
-            --username ${{secrets.DOCKER_USERNAME}} \
-            --password-stdin
-      - run: |
-          docker-template build $DOCKER_REPO --no-push --force --squash
-          docker-template push  $DOCKER_REPO
+          ruby-version: '2'
+          bundler-cache: true
+
+      - name: Generate Dockerfiles
         env:
           RUBYOPT: "-W0"
-          DOCKER_REPO: "${{join(matrix.env, ' ')}}"
+        run: |
+          gem install docker-template
+          docker-template cache
+
+      - name: Set Metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: jekyll/${{ matrix.variant }}
+          flavor: latest=false
+          tags: ${{ matrix.tags }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./repos/${{ matrix.variant }}/cache/${{ matrix.main_tag }}
+          platforms: |
+            linux/386
+            linux/amd64
+            linux/arm/v6
+            linux/arm/v7
+            linux/arm64/v8
+            linux/s390x
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: "--squash"


### PR DESCRIPTION
### Summary of the changes made (TL;DR)

 - Enable building images for multiple architectures within the current workflow
   (fixes #245, fixes #279 and fixes #307)
 - Fix deprecation of setup-ruby action. See [e932e7a][1]
 - Fix missing tag 4.2 to follow 4.2.2
   (fixes #327 and fixes #338)
 - Bringing the build process up to date might indirectly resolve #308
 
[1]: https://github.com/actions/setup-ruby/commit/e932e7af67fc4a8fc77bd86b744acd4e42fe3543


### More in depth

This rewritten deploy workflow achieves supporting multiple architectures without modifications to docker-template and making use of currently available tools to cross-build for different platforms.

I've tried to keep the changes to the current setup to a minimum. I (obviously) could not try this workflow with your credentials but I've tested it with mine and it worked. Got the same repo/tag structure but for multiple (linux) architectures. See job [3951534375][2], it produced images and tags in the following repositories:

 - [jekyll][3]
 - [builder][4]
 - [minimal][5]

The changes include the use of new action 'ruby/setup-ruby' instead of the, now defunct, 'actions/setup-ruby'. See [deprecation notes][1]. This fixes the reason for the current failures on jobs like [3880108024][6].

Also note that current `deploy.yml` creates tags '4' and '4.0' to follow '4.2.2'. IMHO, this should be '4' and '4.2'. Happy to revert the change if it is not a bug.

For this PR to work, first PR #355 needs to be merged. Otherwise all jobs fail (as expected).

I'm happy to make any changes (maybe update to 4.3?) or if you want other formatting with more space or less. Just let me know. I'm happy to elaborate on how anything in this PR works if needed as well.

Cheers


[2]: https://github.com/rockstorm101/jekyll-docker/actions/runs/3951534375
[3]: https://hub.docker.com/r/rockstorm/jekyll-jekyll 
[4]: https://hub.docker.com/r/rockstorm/jekyll-builder
[5]: https://hub.docker.com/r/rockstorm/jekyll-minimal
[6]: https://github.com/envygeeks/jekyll-docker/actions/runs/3880108024
