### PR TITLE
enclosing [::1]:4000:4000 in single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For local development, Jekyll can be run in server mode inside the container. It
 ```sh
 docker run --rm \
   --volume="$PWD:/srv/jekyll:Z" \
-  --publish [::1]:4000:4000 \
+  --publish '[::1]:4000:4000' \
   jekyll/jekyll \
   jekyll serve
 ```


### PR DESCRIPTION
running
```
docker run --rm \
  --volume="$PWD:/srv/jekyll:Z" \
  --publish [::1]:4000:4000 \
  jekyll/jekyll \
  jekyll serve
```
gives
```
zsh: no matches found: [::1]:4000:4000
```
The error message you're seeing suggests that the shell is treating [::1]:4000:4000 as a glob pattern and not finding any matches. To resolve this, I enclosed the publish option in quotes to prevent glob expansion.
